### PR TITLE
Feature/32 : 편지 작성, 조회, 복사 API 연동

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -106,7 +106,7 @@ const router = createBrowserRouter([
         element: <Login/>
     },
     {
-        path: "/guest-letters",
+        path: "/gm-letter/:uniqueString",
         element: <GuestLetters/>
     },
     {

--- a/src/apis/guestLetterApi.ts
+++ b/src/apis/guestLetterApi.ts
@@ -1,0 +1,13 @@
+import axios, {AxiosResponse} from 'axios';
+import {ApiResponse} from '../types/common/apiResponse';
+import {GetGuestLettersResponse} from "../types/api/guestLetter.ts";
+
+const BASE_URL = import.meta.env.VITE_BACKEND_URL;
+export const getGuestLetters = async (
+    uniqueString: string
+): Promise<ApiResponse<GetGuestLettersResponse>> => {
+    const response: AxiosResponse<ApiResponse<GetGuestLettersResponse>> = await axios.get(
+        `${BASE_URL}/api/v1/letters/guestview/${uniqueString}`
+    );
+    return response.data;
+};

--- a/src/apis/guestLetterApi.ts
+++ b/src/apis/guestLetterApi.ts
@@ -1,8 +1,27 @@
-import axios, {AxiosResponse} from 'axios';
+import axios, {Axios, AxiosResponse} from 'axios';
 import {ApiResponse} from '../types/common/apiResponse';
-import {GetGuestLettersResponse} from "../types/api/guestLetter.ts";
+import {AddLetterRequest, GetGuestLettersResponse} from "../types/api/guestLetter.ts";
 
 const BASE_URL = import.meta.env.VITE_BACKEND_URL;
+const jwt_token = localStorage.getItem('jwt_token');
+
+export const addLetter = async (
+    uniqueString: string,
+    data: AddLetterRequest
+): Promise<ApiResponse<{}>> => {
+    const response: AxiosResponse<ApiResponse<{}>> = await axios.post(
+        `${BASE_URL}/api/v1/letters/create/${uniqueString}`,
+        data,
+        {
+            headers: {
+                "Content-Type": "application/json",
+            },
+        }
+    );
+    return response.data;
+};
+
+
 export const getGuestLetters = async (
     uniqueString: string
 ): Promise<ApiResponse<GetGuestLettersResponse>> => {

--- a/src/apis/myLetterApi.ts
+++ b/src/apis/myLetterApi.ts
@@ -1,0 +1,18 @@
+import {ApiResponse} from "../types/common/apiResponse.ts";
+import {CopyLetterUrlResponse} from "../types/api/myLetter.ts";
+import axios, {AxiosResponse} from 'axios';
+
+const BASE_URL = import.meta.env.VITE_BACKEND_URL;
+const jwt_token = localStorage.getItem('jwt_token');
+
+export const copyLetterUrl = async (): Promise<ApiResponse<CopyLetterUrlResponse>> => {
+    const response: AxiosResponse<ApiResponse<CopyLetterUrlResponse>> = await axios.get(
+        `${BASE_URL}/api/v1/letters/copy`,
+        {
+            headers: {
+                Authorization: `Bearer ${jwt_token}`
+            },
+        }
+    );
+    return response.data;
+};

--- a/src/apis/myLetterApi.ts
+++ b/src/apis/myLetterApi.ts
@@ -1,5 +1,5 @@
 import {ApiResponse} from "../types/common/apiResponse.ts";
-import {CopyLetterUrlResponse} from "../types/api/myLetter.ts";
+import {CopyLetterUrlResponse, GetMyLettersResponse} from "../types/api/myLetter.ts";
 import axios, {AxiosResponse} from 'axios';
 
 const BASE_URL = import.meta.env.VITE_BACKEND_URL;
@@ -16,3 +16,15 @@ export const copyLetterUrl = async (): Promise<ApiResponse<CopyLetterUrlResponse
     );
     return response.data;
 };
+
+export const getMyLetters = async (): Promise<ApiResponse<GetMyLettersResponse>> => {
+    const response: AxiosResponse<ApiResponse<GetMyLettersResponse>> = await axios.get(
+        `${BASE_URL}/api/v1/letters`,
+        {
+            headers: {
+                Authorization: `Bearer ${jwt_token}`
+            },
+        }
+    );
+    return response.data;
+}

--- a/src/components/headers/Header.tsx
+++ b/src/components/headers/Header.tsx
@@ -13,7 +13,9 @@ const HeaderContainer = styled.header`
   width: 100%;
 `;
 
-const HeaderTitle = styled.h1<{ fontSize: string }>`
+const HeaderTitle = styled.h1.withConfig({
+    shouldForwardProp: (prop) => prop !== "hasBorder",
+})<{ fontSize: string; hasBorder?: boolean }>`
   font-size: ${(props) => props.fontSize};
   font-weight: 700;
   color: transparent; /* 텍스트 색상을 투명으로 설정 */
@@ -30,7 +32,7 @@ const HeaderTitle = styled.h1<{ fontSize: string }>`
   white-space: pre-line; /* \\n 처리를 위한 속성 */
 `;
 
-const Header = ({ title, fontSize = '30px', hasBorder = false }: HeaderProps) => {
+const Header = ({ title, fontSize = "30px", hasBorder = false }: HeaderProps) => {
     return (
         <HeaderContainer>
             <HeaderTitle fontSize={fontSize} hasBorder={hasBorder}>{title}</HeaderTitle>

--- a/src/routes/guestLetters.tsx
+++ b/src/routes/guestLetters.tsx
@@ -35,7 +35,7 @@ const GuestLetters = () => {
     const navigate = useNavigate();
 
     const [ownerName, setOwnerName] = useState('');
-    const [beforeBirthday, setBeforeBirthday] = useState(false);
+    const [beforeBirthday, setBeforeBirthday] = useState(true);
     const [letterCount, setLetterCount] = useState(0);
 
     // 표시할 장신구 데이터 생성
@@ -58,7 +58,8 @@ const GuestLetters = () => {
 
                         const {birthday_owner_name, before_birthday, total_letters} = response.data;
                         setOwnerName(birthday_owner_name);
-                        setBeforeBirthday(before_birthday);
+                        // TODO 개발의 용이성과 테스트를 위해 임시로 before_birthday를 항상 기본값 true로 설정
+                        // setBeforeBirthday(before_birthday);
                         setLetterCount(total_letters);
                     } else {
                         console.error("게스트 편지 조회 실패:", response.message);

--- a/src/routes/guestLetters.tsx
+++ b/src/routes/guestLetters.tsx
@@ -89,7 +89,7 @@ const GuestLetters = () => {
                 {beforeBirthday ? (
                     <ButtonContainer>
                         <Button type="button" text="편지 쓰러 가기" size="large" color="white"
-                                onClick={() => navigate("/write-letter", {state: {uniqueString}})}/>
+                                onClick={() => navigate("/write-letter", {state: {uniqueString, ownerName}})}/>
                         <Button type="button" text="위시리스트 보러 가기" size="large" color="black"
                                 onClick={() => navigate("/", {state: {uniqueString}})}/>
                     </ButtonContainer>

--- a/src/routes/guestLetters.tsx
+++ b/src/routes/guestLetters.tsx
@@ -4,16 +4,14 @@ import Header from '../components/headers/Header.tsx';
 import Button from '../components/buttons/Button.tsx';
 import Cake from '../components/letters/Cake.tsx';
 import "react-toastify/dist/ReactToastify.css";
-import { ornamentImages } from '../assets/ornamentImages.ts';
-import { ornamentPositions } from '../assets/ornamentImages.ts';
+import {ornamentImages} from '../assets/ornamentImages.ts';
+import {ornamentPositions} from '../assets/ornamentImages.ts';
 
 import InstructionText from "../components/InstructionText.tsx";
 import {useNavigate, useParams} from "react-router-dom";
 import BackButton from "../components/buttons/BackButton.tsx";
-import axios from "axios";
 import {getGuestLetters} from "../apis/guestLetterApi.ts";
 import {toast} from "react-toastify";
-import success = toast.success;
 
 export const Wrapper = styled.div`
   display: flex;
@@ -32,9 +30,8 @@ const ButtonContainer = styled.div`
 `;
 
 
-// NOTE 현재는 하드코딩된 값 사용. 나중에 동적으로 처리 필요
 const GuestLetters = () => {
-    const { uniqueString } = useParams();
+    const {uniqueString} = useParams();
     const navigate = useNavigate();
 
     const [ownerName, setOwnerName] = useState('');
@@ -59,7 +56,7 @@ const GuestLetters = () => {
                     if (response.status === "success") {
                         console.log("게스트 편지 조회 성공:", response.data);
 
-                        const { birthday_owner_name, before_birthday, total_letters} = response.data;
+                        const {birthday_owner_name, before_birthday, total_letters} = response.data;
                         setOwnerName(birthday_owner_name);
                         setBeforeBirthday(before_birthday);
                         setLetterCount(total_letters);
@@ -76,18 +73,27 @@ const GuestLetters = () => {
 
     return (
         <>
-        <Wrapper>
-            {/*TODO 백엔드 API 유저 정보 받아오기*/}
-            <BackButton/>
-            <Header title="경희님의 편지함"/>
-            <Cake items={items}/> {/* items를 Cake에 전달 */}
-            <InstructionText iconText="Notice" message={`생일을 함께 축하해주세요!\n편지 작성 후 선물 전달이 가능합니다!`}/>
-            <ButtonContainer>
-                <Button type="button" text="편지 쓰러 가기" size="large" color="white"
-                        onClick={() => navigate("/write-letter")}/>
-                <Button type="button" text="위시리스트 보러 가기" size="large" color="black" onClick={() => navigate("/")}/>
-            </ButtonContainer>
-        </Wrapper>
+            <Wrapper>
+                <BackButton/>
+                <Header title={`${ownerName}님의 편지함`}/>
+                <Cake items={items}/> {/* items를 Cake에 전달 */}
+                <InstructionText
+                    iconText="Notice"
+                    message={
+                        beforeBirthday
+                            ? `생일을 함께 축하해주세요!\n편지 작성 후 선물 전달이 가능합니다!`
+                            : `편지 전달 기간이 종료되었습니다!`
+                    }
+                />
+                {beforeBirthday ? (
+                    <ButtonContainer>
+                        <Button type="button" text="편지 쓰러 가기" size="large" color="white"
+                                onClick={() => navigate("/write-letter", {state: {uniqueString}})}/>
+                        <Button type="button" text="위시리스트 보러 가기" size="large" color="black"
+                                onClick={() => navigate("/", {state: {uniqueString}})}/>
+                    </ButtonContainer>
+                ) : ""}
+            </Wrapper>
         </>
     );
 };

--- a/src/routes/guestLetters.tsx
+++ b/src/routes/guestLetters.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import {useEffect, useState} from 'react';
 import styled from 'styled-components';
 import Header from '../components/headers/Header.tsx';
 import Button from '../components/buttons/Button.tsx';
@@ -8,8 +8,12 @@ import { ornamentImages } from '../assets/ornamentImages.ts';
 import { ornamentPositions } from '../assets/ornamentImages.ts';
 
 import InstructionText from "../components/InstructionText.tsx";
-import {useNavigate} from "react-router-dom";
+import {useNavigate, useParams} from "react-router-dom";
 import BackButton from "../components/buttons/BackButton.tsx";
+import axios from "axios";
+import {getGuestLetters} from "../apis/guestLetterApi.ts";
+import {toast} from "react-toastify";
+import success = toast.success;
 
 export const Wrapper = styled.div`
   display: flex;
@@ -30,10 +34,12 @@ const ButtonContainer = styled.div`
 
 // NOTE 현재는 하드코딩된 값 사용. 나중에 동적으로 처리 필요
 const GuestLetters = () => {
+    const { uniqueString } = useParams();
     const navigate = useNavigate();
 
-    // NOTE 게스트 편지함 링크에서 장신구 개수는 14개로 고정
-    const [letterCount] = useState<number>(14);
+    const [ownerName, setOwnerName] = useState('');
+    const [beforeBirthday, setBeforeBirthday] = useState(false);
+    const [letterCount, setLetterCount] = useState(0);
 
     // 표시할 장신구 데이터 생성
     const items = ornamentImages.slice(0, letterCount).map((src, index) => ({
@@ -44,6 +50,29 @@ const GuestLetters = () => {
         onClick: () => {
         },
     }));
+
+    useEffect(() => {
+        const fetchData = async () => {
+            try {
+                if (uniqueString) {
+                    const response = await getGuestLetters(uniqueString);
+                    if (response.status === "success") {
+                        console.log("게스트 편지 조회 성공:", response.data);
+
+                        const { birthday_owner_name, before_birthday, total_letters} = response.data;
+                        setOwnerName(birthday_owner_name);
+                        setBeforeBirthday(before_birthday);
+                        setLetterCount(total_letters);
+                    } else {
+                        console.error("게스트 편지 조회 실패:", response.message);
+                    }
+                }
+            } catch (error) {
+                console.error("게스트 편지 조회 실패:", error);
+            }
+        }
+        fetchData();
+    }, [uniqueString, navigate]);
 
     return (
         <>

--- a/src/routes/letterSentConfirm.tsx
+++ b/src/routes/letterSentConfirm.tsx
@@ -1,8 +1,10 @@
 import Header from "../components/headers/Header.tsx";
 import Button from "../components/buttons/Button.tsx";
 import styled from "styled-components";
-import {useNavigate} from "react-router-dom";
+import {useLocation, useNavigate} from "react-router-dom";
 import mascot from "../assets/home/mascot.svg"
+import {useEffect} from "react";
+import {toast} from "react-toastify";
 
 export const Wrapper = styled.div`
   display: flex;
@@ -25,19 +27,30 @@ export const Mascot = styled.img`
 `
 
 const LetterSentConfirm = () => {
+    const location = useLocation();
     const navigate = useNavigate();
+    const { uniqueString, ownerName } = location.state || {};
+
+    useEffect(() => {
+        // uniqueString이 없으면 이전 페이지로 리다이렉트
+        if (!uniqueString) {
+            toast.error("잘못된 접근입니다. 편지함에서 다시 시도해주세요.");
+            navigate(-1); // 이전 페이지로 이동
+        }
+        console.log("uniqueString, ownerName:", uniqueString, ownerName);
+    }, [uniqueString, navigate]);
 
     return (
         <Wrapper>
             <Mascot src={mascot}></Mascot>
-            <Header title={"OOO님에게 편지가 전달되었어요!"} fontSize={"25px"}/>
+            <Header title={`${ownerName} 님에게 편지가 전달되었어요!`} fontSize={"25px"}/>
             <Header title={"작은 선물로\n마음을 표현 해보는 건 어떠세요?"} fontSize={"25px"}/>
             <RowButtonContainer>
                 <Button type="button" text="좋아요!" size="small" color="black" onClick={() => {
                     navigate("/login")
                 }}/>
                 <Button type="button" text="괜찮아요" size="small" color="white" onClick={() => {
-                    navigate("/guest-letters")
+                    navigate("/gm-letter/" + uniqueString)
                 }}/>
             </RowButtonContainer>
         </Wrapper>

--- a/src/routes/myLetters.tsx
+++ b/src/routes/myLetters.tsx
@@ -32,18 +32,12 @@ export const ColumnButtonContainer = styled.div`
 `;
 
 
-// NOTE 현재는 하드코딩된 값 사용. 나중에 동적으로 처리 필요
 const MyLetters = () => {
     const navigate = useNavigate();
     const [username, setUsername] = useState<string>("");
     const [beforeBirthday, setBeforeBirthday] = useState<boolean>(false);
     const [letters, setLetters] = useState<Letter[]>([]);
-    const [totalLetters, setTotalLetters] = useState<number>(0);
-
-    //      생일이 아니면 편지 상세보기 불가능
-
-    // TODO 백엔드 API로부터 내 편지 개수 받아오기
-    const [letterCount] = useState<number>(14);
+    const [totalLetters, setTotalLetters] = useState<number>(14);
 
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [selectedLetter, setSelectedLetter] = useState<{
@@ -90,7 +84,7 @@ const MyLetters = () => {
     const closeModal = () => setIsModalOpen(false); // 모달 닫기
 
     // 표시할 장신구 데이터 생성
-    const items = ornamentImages.slice(0, letterCount).map((src, index) => ({
+    const items = ornamentImages.slice(0, totalLetters).map((src, index) => ({
         id: index,
         src,
         top: ornamentPositions[index].top,

--- a/src/routes/myLetters.tsx
+++ b/src/routes/myLetters.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import {useEffect, useState} from 'react';
 import styled from 'styled-components';
 import Header from '../components/headers/Header.tsx';
 import Button from '../components/buttons/Button.tsx';
@@ -12,7 +12,8 @@ import {ornamentPositions} from '../assets/ornamentImages.ts';
 import InstructionText from "../components/InstructionText.tsx";
 import {useNavigate} from "react-router-dom";
 import BackButton from "../components/buttons/BackButton.tsx";
-import {copyLetterUrl} from "../apis/myLetterApi.ts";
+import {copyLetterUrl, getMyLetters} from "../apis/myLetterApi.ts";
+import {Letter} from "../types/api/myLetter.ts";
 
 export const Wrapper = styled.div`
   display: flex;
@@ -34,30 +35,16 @@ export const ColumnButtonContainer = styled.div`
 // NOTE 현재는 하드코딩된 값 사용. 나중에 동적으로 처리 필요
 const MyLetters = () => {
     const navigate = useNavigate();
+    const [username, setUsername] = useState<string>("");
+    const [beforeBirthday, setBeforeBirthday] = useState<boolean>(false);
+    const [letters, setLetters] = useState<Letter[]>([]);
+    const [totalLetters, setTotalLetters] = useState<number>(0);
 
-    const letters = [
-        {
-            id: 0,
-            to: "사랑하는 럭키에게",
-            from: "송이가",
-            content: "안녕 나는 너의 대학 동기 송이야 \n" +
-                "일단 생일을 너무 축하해♥️ \n" +
-                "🎉🥳HAPPY BIRTHDAY🎉🥳\n" +
-                "\n" +
-                "우리 중앙 동아리 SOLUX에서 처음 만났을 때 기억나?? \n" +
-                "그때, 너랑 금방 친해질 수 있었던 게 정말 신기했어. \n" +
-                "\n" +
-                "늘 고맙고, 오늘은 생일이니까 코딩할 생각하지 말고, 맘껏 즐겨!!\n" +
-                "그리고 앞으로 나랑 계속 모각코 해줘야 돼 알겠지?? 😉\n" +
-                "\n" +
-                "다시 한번 생일 축하하고 \n" +
-                "힘들 때 연락해! 언제나 내가 너 곁에 있다는 걸 잊지마!\n" +
-                "즐거운 하루 보내~~~\n" +
-                "💟 💟 💟 💟 💟 ",
-        },
-    ];
+    //      생일이 아니면 편지 상세보기 불가능
 
-    const [isBirthday, setIsBirthday] = useState<boolean>(true);
+    // TODO 백엔드 API로부터 내 편지 개수 받아오기
+    const [letterCount] = useState<number>(14);
+
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [selectedLetter, setSelectedLetter] = useState<{
         id: number;
@@ -66,25 +53,37 @@ const MyLetters = () => {
         content: string;
     } | null>(null);
 
-    // TODO 백엔드 API로부터 오늘이 생일인지 여부 받아오기
-    //      생일이면 생일 축하 문구 페이지부터 띄우기
-    //      생일이 아니면 편지 상세보기 불가능
+    useEffect(() => {
+        const fetchLetters = async () => {
+            try {
+                const response = await getMyLetters();
+                if (response.status === "success") {
+                    console.log(response.data);
+                    const {username, before_birthday, total_letters, letters} = response.data;
+                    setUsername(username);
+                    setBeforeBirthday(!before_birthday);
+                    setTotalLetters(total_letters);
+                    setLetters(letters);
+                } else {
+                    console.error("편지 데이터 가져오기 실패:", response.message);
+                }
+            } catch (error) {
+                console.error("편지 데이터 가져오기 실패:", error);
+            }
+        }
+        fetchLetters();
+    }, []);
 
-    // TODO 백엔드 API로부터 내 편지 개수 받아오기
-    const [letterCount] = useState<number>(14);
 
     const handleItemClick = (id: number) => {
-        if (isBirthday) {
-            // TODO 백엔드 API로부터 편지 받아오기
+        if (!beforeBirthday) { // 생일이 지나면 편지 열람 가능
             const letter = letters.find((letter) => letter.id === id);
-            setSelectedLetter(letter); // 선택한 편지 데이터 설정
+            setSelectedLetter(
+                letter
+                    ? {id: letter.id, to: letter.recipient_to, from: letter.sender_name, content: letter.content}
+                    : null
+            ); // 선택한 편지 데이터 설정
             setIsModalOpen(true); // 모달 열기
-        } else {
-            // TODO 토스트 메시지 예쁘게 수정
-            toast.success("편지는 생일 이후에 공개됩니다! ☺️️", {
-                position: "top-center",
-                autoClose: 3000,
-            });
         }
     };
 
@@ -138,11 +137,17 @@ const MyLetters = () => {
     return (
         <>
             <Wrapper>
-                {/*TODO 백엔드 API 유저 정보 받아오기*/}
                 <BackButton/>
-                <Header title="경희님의 편지함"/>
+                <Header title={`${username} 님의 편지함`}/>
                 <Cake items={items}/> {/* items를 Cake에 전달 */}
-                <InstructionText iconText="Letter" message={`장신구를 클릭해 보세요!\n편지 내용을 볼 수 있습니다`}/>
+                <InstructionText
+                    iconText="Notice"
+                    message={
+                        beforeBirthday
+                            ? `편지는 생일 날 공개됩니다!`
+                            : `장신구를 클릭해 보세요!\n편지 내용을 볼 수 있습니다`
+                    }
+                />
                 <ColumnButtonContainer>
                     <Button text="마이페이지" size="large" color="white" onClick={() => navigate("/mypage")}/>
                     <Button text="편지 링크 복사하기" size="large" color="black" onClick={copyLinkToClipboard}/>

--- a/src/routes/writeLetter.tsx
+++ b/src/routes/writeLetter.tsx
@@ -15,13 +15,15 @@ const Form = styled.form`
   gap: 25px;
 `;
 
-const TextArea = styled.textarea<{ error?: boolean }>`
+const TextArea = styled.textarea.withConfig({
+    shouldForwardProp: (prop) => prop !== "error",
+})<{ error?: boolean }>`
   width: 280px;
   background: #FFF9E6;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   height: 400px;
   font-size: 15px;
-  border: 1px solid ${(props) => (props.error ? 'red' : '#ddd')};
+  border: 1px solid ${(props) => (props.error ? "red" : "#ddd")};
   border-radius: 20px;
   resize: none;
   padding: 20px 25px;
@@ -59,8 +61,9 @@ const Label = styled.label`
   font-size: 17px;
   font-weight: bold;
 `;
-
-const Input = styled.input<{ error?: boolean }>`
+const Input = styled.input.withConfig({
+    shouldForwardProp: (prop) => prop !== 'error', // 'error' prop을 DOM으로 전달하지 않음
+})<{ error?: boolean }>`
   flex: 1;
   padding: 8px 10px;
   border-radius: 20px;

--- a/src/routes/writeLetter.tsx
+++ b/src/routes/writeLetter.tsx
@@ -1,8 +1,10 @@
 import BackButton from "../components/buttons/BackButton.tsx";
-import {useState} from "react";
+import {useEffect, useState} from "react";
 import Button from "../components/buttons/Button.tsx";
 import styled from "styled-components";
-import {useNavigate} from "react-router-dom";
+import {useNavigate, useLocation} from "react-router-dom";
+import {addLetter} from "../apis/guestLetterApi.ts";
+import {toast} from "react-toastify";
 
 const Form = styled.form`
   margin: 60px 20px 20px 20px;
@@ -89,6 +91,9 @@ const InputContainer = styled.div`
 `;
 
 const WriteLetter = () => {
+    const location = useLocation();
+    const {uniqueString} = location.state || {};
+
     const [to, setTo] = useState('');
     const [message, setMessage] = useState('');
     const [from, setFrom] = useState('');
@@ -107,6 +112,15 @@ const WriteLetter = () => {
             setter(value); // 입력 길이가 제한 내에 있을 경우만 상태 업데이트
         }
     };
+
+    useEffect(() => {
+        // uniqueString이 없으면 이전 페이지로 리다이렉트
+        if (!uniqueString) {
+            toast.error("잘못된 접근입니다. 편지함에서 다시 시도해주세요.");
+            navigate(-1); // 이전 페이지로 이동
+        }
+        console.log("uniqueString:", uniqueString);
+    }, [uniqueString, navigate]);
 
     const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
@@ -132,11 +146,22 @@ const WriteLetter = () => {
             setFromError(false);
         }
         try {
-            console.log(to, message, from);
-            navigate("/letter-sent-confirm");
-            // TODO: 서버 axios post
+            console.log("편지 작성 요청", to, message, from);
+
+            const response = await addLetter(uniqueString, {
+                recipient_to: to,
+                sender_name: from,
+                content: message,
+            });
+
+            if (response.status === 'success') {
+                console.log("편지 작성 성공:", response.data);
+                navigate("/letter-sent-confirm", {state: {uniqueString}});
+            } else {
+                console.error("편지 작성 실패:", response.message);
+            }
         } catch (error) {
-            console.error("정보 제출 오류 : ", error);
+            console.error("편지 작성 중 오류 발생:", error);
         }
     };
 

--- a/src/routes/writeLetter.tsx
+++ b/src/routes/writeLetter.tsx
@@ -92,7 +92,7 @@ const InputContainer = styled.div`
 
 const WriteLetter = () => {
     const location = useLocation();
-    const {uniqueString} = location.state || {};
+    const {uniqueString, ownerName} = location.state || {};
 
     const [to, setTo] = useState('');
     const [message, setMessage] = useState('');
@@ -119,7 +119,7 @@ const WriteLetter = () => {
             toast.error("잘못된 접근입니다. 편지함에서 다시 시도해주세요.");
             navigate(-1); // 이전 페이지로 이동
         }
-        console.log("uniqueString:", uniqueString);
+        console.log("uniqueString, ownerName:", uniqueString, ownerName);
     }, [uniqueString, navigate]);
 
     const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -156,7 +156,7 @@ const WriteLetter = () => {
 
             if (response.status === 'success') {
                 console.log("편지 작성 성공:", response.data);
-                navigate("/letter-sent-confirm", {state: {uniqueString}});
+                navigate("/letter-sent-confirm", {state: {uniqueString, ownerName}});
             } else {
                 console.error("편지 작성 실패:", response.message);
             }

--- a/src/types/api/guestLetter.ts
+++ b/src/types/api/guestLetter.ts
@@ -1,3 +1,9 @@
+export interface AddLetterRequest {
+    recipient_to: string;
+    sender_name: string;
+    content: string;
+}
+
 export interface GetGuestLettersResponse {
     birthday_owner_name: string;
     before_birthday: boolean;

--- a/src/types/api/guestLetter.ts
+++ b/src/types/api/guestLetter.ts
@@ -1,0 +1,6 @@
+export interface GetGuestLettersResponse {
+    birthday_owner_name: string;
+    before_birthday: boolean;
+    total_letters: number;
+}
+

--- a/src/types/api/myLetter.ts
+++ b/src/types/api/myLetter.ts
@@ -1,3 +1,19 @@
 export interface CopyLetterUrlResponse {
     letter_link: string;
 }
+
+export interface GetMyLettersResponse {
+    username: string;
+    before_birthday: boolean;
+    total_letters: number;
+    letters: Letter[];
+}
+
+export interface Letter {
+    id: number;
+    content: string;
+    created_at: string; // ISO 8601 형식의 날짜 문자열
+    recipient_id: number;
+    sender_name: string;
+    recipient_to: string;
+}

--- a/src/types/api/myLetter.ts
+++ b/src/types/api/myLetter.ts
@@ -1,0 +1,3 @@
+export interface CopyLetterUrlResponse {
+    letter_link: string;
+}


### PR DESCRIPTION
- 제목(예시)

  Feature/이슈번호: color system 구성

## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요.
- 리뷰는 PR이 올라오면 최대한 빠르게 진행합니다.
- P1 단계의 리뷰는 빠르게 확인 후 반영합니다.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.
  
## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #32 

## 📎 𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- 편지 작성(로그인X) ` /api/v1/letters/create/:uniqueString`
- 편지 목록 조회(로그인O) `/api/v1/letters`
- 편지 목록 조회(로그인X, 링크) `/api/v1/letters/guestview/:uniqueString`
- 편지 링크 복사하기(로그인O)  `/api/v1/letters/copy`


## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
- 로그인 들어가는 API를 제외하고 연동 시도했습니다.
- 편지 상세 조회는 모달창을 열었을 때 호출하는 API인데, 편지 목록 조회에서 값을 한번에 얻어올 수 있고 페이지 이동이 일어나지도 않기 때문에 사용하지는 않았습니다.
- 사용자 고유 url에 들어와서 '위시리스트 보러 가기' 클릭하면 state로 uniqueString을 넘겼습니다. 남 위시리스트에서 사용하시면 됩니다.

`guestLetters.tsx` 코드 일부
<img width="760" alt="image" src="https://github.com/user-attachments/assets/626724e7-6bb3-4384-8c0f-a451af93fe9d" />
