### PR TITLE
Feature/49 : API 401 에러 해결 & 선물 수정 시 '+' 아이콘 미표시 문제 해결

### DIFF
--- a/src/apis/myLetterApi.ts
+++ b/src/apis/myLetterApi.ts
@@ -3,9 +3,8 @@ import {CopyLetterUrlResponse, GetMyLettersResponse} from "../types/api/myLetter
 import axios, {AxiosResponse} from 'axios';
 
 const BASE_URL = import.meta.env.VITE_BACKEND_URL;
-const jwt_token = localStorage.getItem('jwt_token');
-
 export const copyLetterUrl = async (): Promise<ApiResponse<CopyLetterUrlResponse>> => {
+    const jwt_token = localStorage.getItem('jwt_token');
     const response: AxiosResponse<ApiResponse<CopyLetterUrlResponse>> = await axios.get(
         `${BASE_URL}/api/v1/letters/copy`,
         {
@@ -18,6 +17,7 @@ export const copyLetterUrl = async (): Promise<ApiResponse<CopyLetterUrlResponse
 };
 
 export const getMyLetters = async (): Promise<ApiResponse<GetMyLettersResponse>> => {
+    const jwt_token = localStorage.getItem('jwt_token');
     const response: AxiosResponse<ApiResponse<GetMyLettersResponse>> = await axios.get(
         `${BASE_URL}/api/v1/letters`,
         {

--- a/src/apis/wishItemApi.ts
+++ b/src/apis/wishItemApi.ts
@@ -3,10 +3,10 @@ import {AddWishResponse, GetWishResponse} from '../types/api/wishItem';
 import {ApiResponse} from '../types/common/apiResponse';
 
 const BASE_URL = import.meta.env.VITE_BACKEND_URL;
-const jwt_token = localStorage.getItem('jwt_token');
 export const addWishItem = async (
     data: FormData
 ): Promise<ApiResponse<AddWishResponse>> => {
+    const jwt_token = localStorage.getItem('jwt_token');
     const response: AxiosResponse<ApiResponse<AddWishResponse>> = await axios.post(
         `${BASE_URL}/api/v1/wishlists`,
         data,
@@ -23,6 +23,7 @@ export const addWishItem = async (
 export const getWishItem = async (
     itemId: number
 ): Promise<ApiResponse<GetWishResponse>> => {
+    const jwt_token = localStorage.getItem('jwt_token');
     const response: AxiosResponse<ApiResponse<GetWishResponse>> = await axios.get(
         `${BASE_URL}/api/v1/wishlists`,
         {
@@ -41,6 +42,7 @@ export const modifyWishItem = async (
     itemId: number,
     data: FormData
 ): Promise<ApiResponse<GetWishResponse>> => {
+    const jwt_token = localStorage.getItem('jwt_token');
     const response: AxiosResponse<ApiResponse<GetWishResponse>> = await axios.patch(
         `${BASE_URL}/api/v1/wishlists/${itemId}`,
         data,
@@ -57,6 +59,7 @@ export const modifyWishItem = async (
 export const deleteWishItem = async (
     itemId: number
 ): Promise<ApiResponse<{}>> => {
+    const jwt_token = localStorage.getItem('jwt_token');
     const response: AxiosResponse<ApiResponse<{}>> = await axios.delete(
         `${BASE_URL}/api/v1/wishlists/${itemId}`,
         {

--- a/src/pages/letters/guestLetters.tsx
+++ b/src/pages/letters/guestLetters.tsx
@@ -71,7 +71,7 @@ const GuestLetters = () => {
                     iconText="Notice"
                     message={
                         beforeBirthday
-                            ? `생일을 함께 축하해주세요!\n편지 작성 후 선물 전달이 가능합니다!`
+                            ? `편지나 선물 전달로 마음을 표현하세요!`
                             : `편지 전달 기간이 종료되었습니다!`
                     }
                 />

--- a/src/pages/wish/myWishModify.tsx
+++ b/src/pages/wish/myWishModify.tsx
@@ -5,7 +5,6 @@ import {useLocation, useNavigate, useParams} from "react-router-dom";
 import {useCallback, useEffect, useMemo, useRef, useState} from "react";
 import Button from "../../components/buttons/Button.tsx";
 import MyWishDeleteConfirm from "../../routes/wish/myWishDeleteConfirm.tsx";
-import cameraIcon from "../../assets/wishlist/wish_img_modify.svg";
 import {deleteWishItem, modifyWishItem} from "../../apis/wishItemApi.ts";
 import {GetWishResponse} from "../../types/api/wishItem.ts";
 import {RowButtonContainer} from "../../components/buttons/ButtonContainer.ts";
@@ -57,7 +56,7 @@ const ImageUploadWrapper = styled.div<{ thumbnail?: string }>`
     position: absolute;
     width: 50px;
     height: 50px;
-    background-image: url(${cameraIcon});
+    background-image: url("/home/wish_img_modify.svg");
     background-size: contain;
     background-repeat: no-repeat;
     top: 50%;


### PR DESCRIPTION
- 제목(예시)

  Feature/이슈번호: color system 구성

## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요.
- 리뷰는 PR이 올라오면 최대한 빠르게 진행합니다.
- P1 단계의 리뷰는 빠르게 확인 후 반영합니다.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.
  
## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #49

## 📎 𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- 편지 안내 문구 수정

- 전반적인 API 호출시 jwt_token을 같이 보내지 못하는 이슈 발생 
  🅿️:  jwt_token을 API 함수 정의 시점에서 호출하고 있어서 컴포넌트가 실행될 때 한 번만 값을 가져오고, 이후로는 변경되지 않음 
  💡: jwt_token을 API 호출 시점에서 가져오기

- 선물 수정시 기존 선물 이미지에 + 버튼 이미지가 올바르게 위치시키도록 함